### PR TITLE
Ajustes no ConfigureServer

### DIFF
--- a/sdkAcesso/iDAccess/iDAccess_Server.cs
+++ b/sdkAcesso/iDAccess/iDAccess_Server.cs
@@ -32,16 +32,20 @@ namespace ControliD.iDAccess
         /// <param name="Overwrite">Apaga server antigo</param>
         public StatusResult ConfigureServer(string server_url, OnlineMode mode, bool Overwrite = false)
         {
-            const long serverId = -1;
-            Devices server = new Devices() { id = serverId, IP = server_url, name = "Server", PublicKey = "anA=" };
+            try
+            {
+                Devices server = new Devices() { id = -1, IP = server_url, name = "Server", PublicKey = "anA=" };
 
-            if (Overwrite)
-                Destroy<Devices>(serverId);
+                if (Overwrite)
+                    DestroyWhere<Devices, WhereObjects>(new WhereObjects() { });
 
-            if (Add(server) == serverId)
+                long serverId = Add(server);
                 return GoOnline(mode, serverId);
-            else
+            }
+            catch (Exception)
+            {
                 return new StatusResult(500, "Não foi possível incluir o servidor no equipamento");
+            }
         }
     }
 


### PR DESCRIPTION
Na versão 6.20.15 do iDFace, inserções no banco com id = -1 geram uma nova entrada com um id incremental na tabela, logo o objeto inserido não terá id = -1, então não faz mais sentido esperar esse mesmo id para verificar se a inserção na tabela `Devices` foi bem sucedida ou não.

Essa "correção" no comportamento do banco de dados do iDFace vai ser revertida no futuro, porém não deveríamos depender de um id negativo para verificar se o equipamento foi configurado corretamente.

A alteração feita agora remove todas os registros da tabela `Devices` e insere um novo registro com a URL fornecida.