### PR TITLE
SW-2495 - Mudar identidade para HID

### DIFF
--- a/sdkAcesso/iDAccess/Device.cs
+++ b/sdkAcesso/iDAccess/Device.cs
@@ -68,7 +68,12 @@ namespace ControliD.iDAccess
             lreq.login = Login;
             lreq.password = Password;
 
+#if HID
+            var result = WebJson.JsonCommand<LoginResult>(URL + "hidlogin.fcgi", lreq, null, TimeOut);
+#else
             var result = WebJson.JsonCommand<LoginResult>(URL + "login.fcgi", lreq, null, TimeOut);
+#endif
+
             if (result is LoginResult)
             {
                 LoginResult dados = (LoginResult)result;
@@ -112,18 +117,14 @@ namespace ControliD.iDAccess
         {
             WebJson.WriteLog();
 
-            if(Session == null)
-            {
+            if (Session == null)
                 Connect();
-            }
             else
             {
                 var result = WebJson.JsonCommand<SessionResult>(URL + "session_is_valid.fcgi?session=" + Session);
                 if (!result.session_is_valid)
-                {
                     Connect();
-                }
             }
-        }        
+        }
     }
 }

--- a/sdkAcesso/iDAccess/Device_Users.cs
+++ b/sdkAcesso/iDAccess/Device_Users.cs
@@ -93,13 +93,13 @@ namespace ControliD.iDAccess
         /// <summary>
         /// Define a foto de um usuário, ou a remove se for informado 'null'
         /// </summary>
-        public void SetUserImage(long nUserID, Image oFoto, bool lTry=false, bool lRecise=false)
+        public string SetUserImage(long nUserID, Image oFoto, bool lTry = false, bool lRecise = false)
         {
             CheckSession();
             try
             {
                 if (oFoto == null)
-                    WebJson.JsonCommand<string>(URL + "user_destroy_image.fcgi?&session=" + Session, "{\"user_id\":" + nUserID + "}", null, TimeOut);
+                    return WebJson.JsonCommand<string>(URL + "user_destroy_image.fcgi?&session=" + Session, "{\"user_id\":" + nUserID + "}", null, TimeOut);
                 else
                 {
                     Image oSend;
@@ -108,13 +108,10 @@ namespace ControliD.iDAccess
                         var width = DeviceImageWidth;
                         var height = DeviceImageHeight;
                         if (oFoto.Height > oFoto.Width)
-                        {
                             height = oFoto.Height * width / oFoto.Width;
-                        }
                         else
-                        {
                             width = oFoto.Width * height / oFoto.Height;
-                        }
+                        
                         Bitmap bmp = new Bitmap(width, height);
                         Graphics graph = Graphics.FromImage(bmp);
                         
@@ -124,10 +121,8 @@ namespace ControliD.iDAccess
                     else
                         oSend = oFoto;
 
-                    WebJson.JsonCommand<string>(URL + "user_set_image.fcgi?user_id=" + nUserID + "&session=" + Session, oSend, null, TimeOut, System.Drawing.Imaging.ImageFormat.Jpeg);
-
-                    // oFoto.Dispose();
-                    // oSend.Dispose();
+                    long timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                    return WebJson.JsonCommand<string>(URL + "user_set_image.fcgi?user_id=" + nUserID + "&timestamp=" + timestamp.ToString() + "&session=" + Session, oSend, null, TimeOut, System.Drawing.Imaging.ImageFormat.Jpeg);
                 }
             }
             catch (Exception ex)
@@ -137,9 +132,9 @@ namespace ControliD.iDAccess
                 else
                     throw ex;
             }
-        }
 
-        
+            return null;
+        }
 
         /// <summary>
         /// Define a foto de uma lista de usuário

--- a/sdkAcesso/iDAccess/Device_Utils.cs
+++ b/sdkAcesso/iDAccess/Device_Utils.cs
@@ -7,8 +7,6 @@ using System.Security.Cryptography;
 
 namespace ControliD.iDAccess
 {
-    //ADICIONAR DEVICE À LISTA
-
     public enum DeviceModels
     {
         iDAccess = 0,
@@ -26,17 +24,17 @@ namespace ControliD.iDAccess
         iDX = 12,
         iDClass = 13,
         iDUHF = 14,
-        //iDAccess_Legacy = 14,
-        //iDFlex_V2 = 15,
         iDFace = 15,
         iDBlock_Facial = 16,
-        iDBlock_Next = 17
+        iDBlock_Next = 17,
+        iDFace_Max = 18,
+        Amico = 19,
+        Amico_7 = 20
     }
 
     public enum DeviceNames
     {
-
-//Modelos iDAccess
+        // Modelos iDAccess
         [Description("iDAccess Bio")]                       B,
         [Description("iDAccess Bio ASK")]                   A,
         [Description("iDAccess Bio ASK+FSK")]               C,
@@ -47,7 +45,7 @@ namespace ControliD.iDAccess
         [Description("iDAccess Prox ASK+PSK")]              H,
         [Description("iDAccess Prox ASK+MIFARE")]           I,
 
-//Modelos iDAccess Pro
+        // Modelos iDAccess Pro
         [Description("iDAccess Pro Bio")]                   _0E01,
         [Description("iDAccess Pro Bio ASK")]               _0E02,
         [Description("iDAccess Pro Bio MIFARE")]            _0E03,
@@ -56,42 +54,42 @@ namespace ControliD.iDAccess
         [Description("iDAccess Pro Bio Prox HID")]          _0E06,
         [Description("iDAccess Pro Prox HID")]              _0E07,
 
-        //Modelos iDAccess Nano
+        // Modelos iDAccess Nano
         [Description("iDAccess Nano Bio")]                  _0F01,
         [Description("iDAccess Nano Bio ASK")]              _0F02,
         [Description("iDAccess Nano Bio MIFARE")]           _0F03,
         [Description("iDAccess Nano Prox ASK")]             _0F04,
         [Description("iDAccess Nano Prox MIFARE")]          _0F05,
 
-//Modelos iDFlex V2
+        // Modelos iDFlex V2
         [Description("iDFlex V2 Bio")]                      _0G01,
         [Description("iDFlex V2 Bio Prox ASK")]             _0G02,
         [Description("iDFlex V2 Bio Prox MIFARE")]          _0G03,
         [Description("iDFlex V2 Prox ASK")]                 _0G04,
         [Description("iDFlex V2 Prox MIFARE")]              _0G05,
 
-//Modelos iDAccess Legacy 
+        // Modelos iDAccess Legacy
         [Description("iDAccess Legacy Bio")]                _0I01,
         [Description("iDAccess Legacy Bio Prox ASK")]       _0I02,
         [Description("iDAccess Legacy Bio Prox MIFARE")]    _0I03,
         [Description("iDAccess Legacy Prox ASK")]           _0I04,
         [Description("iDAccess Legacy Prox MIFARE")]        _0I05,
 
-//Modelos iDFit Legacy
+        // Modelos iDFit Legacy
         [Description("iDFit Legacy Bio")]                   _0J01,
         [Description("iDFit Legacy Bio Prox ASK")]          _0J02,
         [Description("iDFit Legacy Bio Prox MIFARE")]       _0J03,
         [Description("iDFit Legacy Prox ASK")]              _0J04,
         [Description("iDFit Legacy Prox MIFARE")]           _0J05,
 
-// Modelos iDFit
+        // Modelos iDFit
         [Description("iDFit Bio")]                          N,
         [Description("iDFit Bio ASK")]                      M,
         [Description("iDFit Bio ASK+FSK")]                  O,
         [Description("iDFit Bio ASK+PSK")]                  P,
         [Description("iDFit Bio ASK+MIFARE")]               Q,
 
-// Modelos Jalapeno
+        // Modelos Jalapeno
         [Description("iDBox Appliance")]                    J,
         [Description("iDBox Controler")]                    L,
         [Description("iDBlock")]                            K,
@@ -99,31 +97,31 @@ namespace ControliD.iDAccess
         [Description("iDBlock Plus")]                       S,
         [Description("x86")]                                R,
 
-// Novos Seriais
+        // Novos Seriais
         [Description("iDFlex Bio")]                         _0A01,
         [Description("iDFlex Bio Prox ASK")]                _0A02,
         [Description("iDFlex Bio Prox MIFARE")]             _0A03,
         [Description("iDFlex Prox ASK")]                    _0A04,
         [Description("iDFlex Prox MIFARE")]                 _0A05,
 
-// Modelos Light (descontinuado)
+        // Modelos Light (descontinuado)
         //[Description("iDAccess Light Bio")]               Z,
         //[Description("iDAccess Light Bio ASK")]           Y,
         //[Description("iDAccess Light Bio ASK+FSK")]       X,
         //[Description("iDAccess Light Bio ASK+PSK")]       W,
         //[Description("iDAccess Light Bio ASK+MIFARE")]    V,
 
-// iDUHF
+        // iDUHF
         [Description("iDUHF")]                              _0N01,
         [Description("iDUHF Lite")]                         _0N02,
 
-// iDFace
+        // iDFace
         [Description("iDFace Legacy1")]                     _0M01,
         [Description("iDFace Legacy2")]                     _0M02,
         [Description("iDFace")]                             _0M03,
         [Description("iDFace HID")]                         _0M04,
         
-// iDFace Max
+        // iDFace Max
         [Description("iDFace Max")]                         _0X01,
         [Description("iDFace Max Prox ASK")]                _0X02,
         [Description("iDFace Max Prox MIFARE")]             _0X03,
@@ -132,8 +130,14 @@ namespace ControliD.iDAccess
         // iDBox V2
         [Description("iDBox V2")]                           _0L01,
 
-// iDBlock Next IHM
+        // iDBlock Next IHM
         [Description("iDBlock Next IHM")]                   _0T01,
+
+        // Amico
+        [Description("Amico")]                              _0Z01,
+
+        // Amico 7
+        [Description("Amico 7")]                            _1Z01,
 
         [Description("(não identificado)")]                 none
     }
@@ -162,12 +166,12 @@ namespace ControliD.iDAccess
 
         public static bool IsiDFace(DeviceModels model)
         {
-            return (model == DeviceModels.iDFace);
+            return (model == DeviceModels.iDFace || model == DeviceModels.iDFace_Max);
         }
 
         public static bool HasTwoRelays(DeviceModels model)
         {
-            return (model == DeviceModels.iDAccess || model == DeviceModels.iDFit || model == DeviceModels.iDAccessProx);
+            return (model == DeviceModels.iDAccess || model == DeviceModels.iDFit || model == DeviceModels.iDAccessProx || model == DeviceModels.iDFace_Max);
         }
 
         public static bool HasUserDisplay(DeviceModels model)
@@ -265,10 +269,16 @@ namespace ControliD.iDAccess
                 return DeviceModels.iDAccess_Nano;
             else if (cName.Contains("iDUHF"))
                 return DeviceModels.iDUHF;
+            else if (cName.Contains("iDFace Max"))
+                return DeviceModels.iDFace_Max;
             else if (cName.Contains("iDFace"))
                 return DeviceModels.iDFace;
             else if (cName.Contains("iDBlock_Facial"))
                 return DeviceModels.iDBlock_Facial;
+            else if (cName.Contains("Amico 7"))
+                return DeviceModels.Amico_7;
+            else if (cName.Contains("Amico"))
+                return DeviceModels.Amico;
             else
                 return DeviceModels.iDAccess;
         }

--- a/sdkAcesso/sdkAcesso.csproj
+++ b/sdkAcesso/sdkAcesso.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;HID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\sdk-ControliD.xml</DocumentationFile>

--- a/sdkAcesso/sdkAcesso.csproj
+++ b/sdkAcesso/sdkAcesso.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;HID</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\sdk-ControliD.xml</DocumentationFile>
@@ -54,6 +54,28 @@
     <OutputPath>bin\x64\Release\</OutputPath>
     <DocumentationFile>bin\Release\sdk-ControliD.xml</DocumentationFile>
     <Optimize>true</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug HID|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug HID\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;HID</DefineConstants>
+    <DocumentationFile>bin\Debug\sdk-ControliD.xml</DocumentationFile>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug HID|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug HID\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DocumentationFile>bin\Debug\sdk-ControliD.xml</DocumentationFile>
+    <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <LangVersion>7.3</LangVersion>

--- a/sdkAcesso/sdkAcesso.csproj
+++ b/sdkAcesso/sdkAcesso.csproj
@@ -81,6 +81,25 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release HID|AnyCPU'">
+    <OutputPath>bin\Release HID\</OutputPath>
+    <DocumentationFile>bin\Release\sdk-ControliD.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <DefineConstants>HID</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release HID|x64'">
+    <OutputPath>bin\x64\Release HID\</OutputPath>
+    <DocumentationFile>bin\Release\sdk-ControliD.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
Alterações:
- Ajustes para fazer login nos equipamentos da HID;
- Adiciona os modelos do Amico e do Amico 7 na lista de dispositivos. Implementação do iDFace Max, do Amico e do Amico 7 nos métodos apropriados;
- Alterações no método SetUserImage para retornar a resposta do endpoint `user_set_image`;
- Criado perfis de compilação para a versão da HID.