### PR TITLE
Alterar tipo de id para long em DoorStateDetail

### DIFF
--- a/sdkAcesso/iDAccess/Device_Hardware.cs
+++ b/sdkAcesso/iDAccess/Device_Hardware.cs
@@ -56,7 +56,7 @@ namespace ControliD.iDAccess
         public class DoorStateDetail
         {
             [DataMember]
-            public int id;
+            public long id;
             [DataMember]
             public bool open;
         }


### PR DESCRIPTION
O campo id da classe DoorStateDetail foi alterado de int para long, permitindo suportar valores inteiros maiores que é a condição para quando existe SecBox conectada.