### PR TITLE
SW-2976 - Ajustes em classes que herdam a classe Item_Access_Rules

### DIFF
--- a/sdkAcesso/iDAccess/iDAccess_Objects.cs
+++ b/sdkAcesso/iDAccess/iDAccess_Objects.cs
@@ -216,7 +216,7 @@ namespace ControliD.iDAccess
     }
 
     [DataContract]
-    public abstract class Item_Access_Rules : GenericItem
+    public abstract class Item_Access_Rules : GenericCount
     {
         [DataMember(EmitDefaultValue = false)]
         public long access_rule_id;


### PR DESCRIPTION
Ajuste para permitir que classes de regras de acesso possam utilizar o método de contagem.

Erro de cast nos logs do connector do CCure9000:

```
2026-06-17 15:27:27,763 [22] ERROR ControlidCommon.ControlidSyncDevice - SyncOnce - Error in sync routine of the device on 192.168.153.127 - Ex: Unable to cast object of type 'ControliD.iDAccess.User_Access_Rules' to type 'ControliD.iDAccess.GenericCount'.    at ControliD.iDAccess.Device.Count[T](WhereObjects oWhere)
   at ControlidCommon.DisposableDevice.UserAccessRulesList() in C:\ControliD\tyco\ControlidCommon\DisposableDevice.cs:line 138
   at ControlidCommon.ControlidSyncDevice.SendDefaultUserAccessRules(IEnumerable`1 users, DisposableDevice disposableDevice, TypeToSend type) in C:\ControliD\tyco\ControlidCommon\ControlidSyncDevice.cs:line 662
   at ControlidCommon.ControlidSyncDevice.SendUsers(IEnumerable`1 users, ConcurrentDictionary`2 userImagesDict, DisposableDevice disposableDevice, DeviceData deviceData, TypeToSend type, CardModelEnum defaultCardModel) in C:\ControliD\tyco\ControlidCommon\ControlidSyncDevice.cs:line 952
   at ControlidCommon.ControlidSyncDevice.AddOrEditUsersToDevice(InfoToSend info, DisposableDevice disposableDevice, DeviceData deviceData) in C:\ControliD\tyco\ControlidCommon\ControlidSyncDevice.cs:line 628
   at ControlidCommon.ControlidSyncDevice.SyncOnce() in C:\ControliD\tyco\ControlidCommon\ControlidSyncDevice.cs:line 518
```